### PR TITLE
FIX: include stoi

### DIFF
--- a/bank-conflicts/init.cpp
+++ b/bank-conflicts/init.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 
 void run(int offset);
 

--- a/memory-coalescing/init.cpp
+++ b/memory-coalescing/init.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 
 void run(int startOffset, int moveOffset);
 

--- a/shared-memory-limit/init.cpp
+++ b/shared-memory-limit/init.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 
 void run(int sharedMemorySize);
 


### PR DESCRIPTION
Error during the build.
```
mkdir build
cd build
cmake .. -DCMAKE_BUILD_TYPE=Release
cmake --build . --config Release
```
```
error C3861: 'stoi'
```

Need include `<string>` https://en.cppreference.com/w/cpp/string/basic_string/stol